### PR TITLE
Fix deps.edn compilation by reverting to older immuconf version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,14 +1,12 @@
-(defproject uap-clj "1.3.6"
+(defproject uap-clj "1.3.7"
   :description "Clojure language implementation of ua-parser"
   :url "https://github.com/russellwhitaker/uap-clj"
   :license {:name "The MIT License (MIT)"
             :url "http://www.opensource.org/licenses/mit-license.php"}
   :scm {:name "git"
         :url "https://github.com/russellwhitaker/uap-clj"}
-  :dependencies [[org.clojure/clojure      "1.10.1"]
-                 [russellwhitaker/immuconf "0.3.0"
-                   :exclusions [org.clojure/clojurescript
-                                com.taoensso/timbre]]
+  :dependencies [[org.clojure/clojure      "1.10.3"]
+                 [levand/immuconf          "0.1.0"]
                  [clj-commons/clj-yaml     "0.7.0"]]
   :jar-exclusions [#"dev_resources|^test$|test_resources|tests|docs|\.md|LICENSE|package.json"]
   :profiles {:dev


### PR DESCRIPTION
CLJS support of forked child version isn't needed for this repo, but it does break deps.edn compilation with reader literal error.

* See https://github.com/levand/immuconf/issues/10
* Standalone repository to reproduce error at https://github.com/Quezion/example.immuconf-depsedn

* Please merge & release this as 1.3.7 so that we can get an artifact for the modern Clojure community.
  * My teammate suggested I wrap [uap-java](https://github.com/ua-parser/uap-java) instead, but I'd prefer to use this Clojure implementation if it's still supported
  * This repo's use of immuconf is very light; if someone takes over active maintenance, it might be worth moving to an alternative
