### PR TITLE
Fork release com.github.quezion/uap-clj "1.3.8" until move back to main

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,14 +1,12 @@
-(defproject uap-clj "1.3.6"
+(defproject uap-clj "1.3.7"
   :description "Clojure language implementation of ua-parser"
   :url "https://github.com/russellwhitaker/uap-clj"
   :license {:name "The MIT License (MIT)"
             :url "http://www.opensource.org/licenses/mit-license.php"}
   :scm {:name "git"
         :url "https://github.com/russellwhitaker/uap-clj"}
-  :dependencies [[org.clojure/clojure      "1.10.1"]
-                 [russellwhitaker/immuconf "0.3.0"
-                   :exclusions [org.clojure/clojurescript
-                                com.taoensso/timbre]]
+  :dependencies [[org.clojure/clojure      "1.10.3"]
+                 [levand/immuconf          "0.1.0"]
                  [clj-commons/clj-yaml     "0.7.0"]]
   :jar-exclusions [#"dev_resources|^test$|test_resources|tests|docs|\.md|LICENSE|package.json"]
   :profiles {:dev

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject quezion/uap-clj "1.3.8"
   :description "Clojure language implementation of ua-parser"
-  :url "https://github.com/russellwhitaker/uap-clj"
+  :url "https://github.com/quezion/uap-clj"
   :license {:name "The MIT License (MIT)"
             :url "http://www.opensource.org/licenses/mit-license.php"}
   :scm {:name "git"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.quezion/uap-clj "1.3.7"
+(defproject com.github.quezion/uap-clj "1.3.8"
   :description "Clojure language implementation of ua-parser"
   :url "https://github.com/quezion/uap-clj"
   :license {:name "The MIT License (MIT)"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject uap-clj "1.3.7"
+(defproject quezion/uap-clj "1.3.8"
   :description "Clojure language implementation of ua-parser"
   :url "https://github.com/russellwhitaker/uap-clj"
   :license {:name "The MIT License (MIT)"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject quezion/uap-clj "1.3.8"
+(defproject com.github.quezion/uap-clj "1.3.8"
   :description "Clojure language implementation of ua-parser"
   :url "https://github.com/quezion/uap-clj"
   :license {:name "The MIT License (MIT)"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.quezion/uap-clj "1.3.8"
+(defproject com.github.quezion/uap-clj "1.3.7"
   :description "Clojure language implementation of ua-parser"
   :url "https://github.com/quezion/uap-clj"
   :license {:name "The MIT License (MIT)"


### PR DESCRIPTION
Move back to mainstream release of https://github.com/ua-parser/uap-clj/pull/3 when possible

*Edit: meant to include this in my downstream repo. I'm getting swapped around this morning!

Either way, I'd like to see this PR closed & the fork deleted. 👍 

**NOTE:** despite the confusing number 1.3.8, this is actually just a side-release of 1.3.6.