### PR TITLE
Addressed CVE-2022-38752 snakeyaml vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Compiling uap-clj.java.api.browser
 Compiling uap-clj.java.api.device
 Compiling uap-clj.java.api.os
 Compiling uap-clj.os
-Created /Users/whitaker/dev/ua-parser/uap-clj/target/uap-clj-1.5.0.jar
-Created /Users/whitaker/dev/ua-parser/uap-clj/target/uap-clj-1.5.0-standalone.jars
+Created /Users/whitaker/dev/ua-parser/uap-clj/target/uap-clj-1.6.0.jar
+Created /Users/whitaker/dev/ua-parser/uap-clj/target/uap-clj-1.6.0-standalone.jars
 ```
 
 ### Java dependencies
@@ -65,7 +65,7 @@ The basic utility functions of this library comprise `useragent`, `browser`, `os
 ### Commandline (CLI)
 
 ```bash
-/usr/bin/java -jar uap-clj-1.5.0-standalone.jar <input_filename> [<optional_out_filename>]
+/usr/bin/java -jar uap-clj-1.6.0-standalone.jar <input_filename> [<optional_out_filename>]
 ```
 
 This command takes as its first argument the name of a text file containing one useragent per line, and prints a TSV (tab-separated) file - defaulting to `useragent_lookup.tsv` - with this line format:
@@ -165,7 +165,7 @@ If you have an Heroku account, [you can easily deploy a Compojure app there](htt
   (ANY "*" []
        (route/not-found (slurp (io/resource "404.html")))))
 ```
-All you need to enable the use of the `lookup-useragent` function here is to add `[uap-clj "1.5.0"]` to the `:dependencies` vector in your Compojure app's `project.clj`, and `[uap-clj.core :refer [lookup-useragent]]` to the `:require` vector of your `web.clj`. Then you can do this type of thing after deployment:
+All you need to enable the use of the `lookup-useragent` function here is to add `[uap-clj "1.6.0"]` to the `:dependencies` vector in your Compojure app's `project.clj`, and `[uap-clj.core :refer [lookup-useragent]]` to the `:require` vector of your `web.clj`. Then you can do this type of thing after deployment:
 
 ```bash
 → curl --data "ua=AppleCoreMedia/1.0.0.12F69 (Apple TV; U; CPU OS 8_3 like Mac OS X; en_us)" http://<your_app>.herokuapp.com {:ua "AppleCoreMedia/1.0.0.12F69 (Apple TV; U; CPU OS 8_3 like Mac OS X; en_us)", :browser {:family "Other", :patch nil, :major nil, :minor nil}, :os {:family "ATV OS X", :major "", :minor "", :patch "", :patch_minor ""}, :device {:family "AppleTV", :brand "Apple", :model "AppleTV"}}
@@ -193,7 +193,7 @@ Then add these dependencies to your `pom.xml`:
 <dependency>
   <groupId>uap-clj</groupId>
   <artifactId>uap-clj</artifactId>
-  <version>1.5.0</version>
+  <version>1.6.0</version>
 </dependency>
 ```
 
@@ -244,7 +244,7 @@ public class Parser {
 [INFO] Building UapJavaWrapper 1.0-SNAPSHOT
 [INFO] ------------------------------------------------------------------------
 [INFO]
-[INFO] --- exec-maven-plugin:1.5.0:java (default-cli) @ UapJavaWrapper ---
+[INFO] --- exec-maven-plugin:1.6.0:java (default-cli) @ UapJavaWrapper ---
 Browser family: Baidu Explorer
 Browser major number: 1
 Browser minor number: 4

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject uap-clj "1.5.0"
+(defproject uap-clj "1.6.0"
   :description "Clojure language implementation of ua-parser"
   :url "https://github.com/russellwhitaker/uap-clj"
   :license {:name "The MIT License (MIT)"
@@ -7,16 +7,16 @@
         :url "https://github.com/russellwhitaker/uap-clj"}
   :dependencies [[org.clojure/clojure      "1.11.1"]
                  [levand/immuconf          "0.1.0"]
-                 [clj-commons/clj-yaml     "0.7.109"]]
+                 [clj-commons/clj-yaml     "1.0.26"]]
   :jar-exclusions [#"dev_resources|^test$|test_resources|tests|docs|\.md|LICENSE|package.json"]
   :profiles {:dev
               {:dependencies [[criterium "0.4.6"]
                               [speclj    "3.4.1"]]
-               :jvm-opts ["-Xss256M"]
+               :jvm-opts ["-Xss512M"]
                :test-paths ["spec"]}
              :uberjar {:uberjar-exclusions
                         [#"dev_resources|^test$|test_resources|tests|docs|\.md|LICENSE|package.json"]}}
-  :plugins [[lein-ancient  "0.6.15"]
+  :plugins [[lein-ancient  "1.0.0-RC3"]
             [speclj        "3.4.1"]]
   :git-dependencies [["https://github.com/ua-parser/uap-core.git"]]
   :resource-paths ["src/resources/submodules" "src/resources/submodules/tests"]

--- a/spec/uap_clj/browser_spec.clj
+++ b/spec/uap_clj/browser_spec.clj
@@ -2,13 +2,10 @@
   "Test suite for browser lookup functionality"
   (:require [speclj.core :refer :all]
             [uap-clj.browser :refer :all]
-            [uap-clj.common-spec :refer [unknown-ua]]
-            [clj-yaml.core :refer [parse-string]]
-            [clojure.java.io :as io :refer [resource]]
+            [uap-clj.common-spec :refer [unknown-ua load-fixture]]
             [clojure.template :refer [do-template]]))
 
-(def tests (:test_cases (parse-string
-                          (slurp (io/resource "test_ua.yaml")))))
+(def tests (load-fixture "test_ua.yaml"))
 
 (defn run-browser-fixture
   "Assert match between fixture test data:

--- a/spec/uap_clj/common_spec.clj
+++ b/spec/uap_clj/common_spec.clj
@@ -1,3 +1,27 @@
-(ns uap-clj.common-spec)
+(ns uap-clj.common-spec
+  (:require [clojure.java.io :as io :refer [resource]]
+            [clj-yaml.core :refer [parse-string default-loader-options]])
+  (:import [org.yaml.snakeyaml LoaderOptions]))
 
-(def unknown-ua "Unknown new useragent in the wild/v0.1.0")
+(def ^:const unknown-ua "Unknown new useragent in the wild/v0.1.0")
+
+(defn default-codepoint-limit
+  []
+  (let [options (LoaderOptions.)]
+    (.getCodePointLimit options)))
+
+(defn snakeyaml-loader-options
+  ^LoaderOptions [n]
+  (let [options (LoaderOptions.)]
+    (.setCodePointLimit options n)
+    options))
+
+(defn load-fixture
+  [f]
+  (let [raw-file (slurp (io/resource f))
+        file-size (count raw-file)]
+    (if (>= file-size (default-codepoint-limit))
+      (:test_cases
+        (with-redefs-fn {#'clj-yaml.core/default-loader-options #(snakeyaml-loader-options file-size)}
+          #(parse-string raw-file)))
+      (:test_cases (parse-string raw-file)))))

--- a/spec/uap_clj/common_spec.clj
+++ b/spec/uap_clj/common_spec.clj
@@ -1,6 +1,6 @@
 (ns uap-clj.common-spec
   (:require [clojure.java.io :as io :refer [resource]]
-            [clj-yaml.core :refer [parse-string default-loader-options]])
+            [clj-yaml.core :refer [parse-string]])
   (:import [org.yaml.snakeyaml LoaderOptions]))
 
 (def ^:const unknown-ua "Unknown new useragent in the wild/v0.1.0")
@@ -22,6 +22,6 @@
         file-size (count raw-file)]
     (if (>= file-size (default-codepoint-limit))
       (:test_cases
-        (with-redefs-fn {#'clj-yaml.core/default-loader-options #(snakeyaml-loader-options file-size)}
-          #(parse-string raw-file)))
+        (with-redefs [clj-yaml.core/default-loader-options #(snakeyaml-loader-options file-size)]
+          (parse-string raw-file)))
       (:test_cases (parse-string raw-file)))))

--- a/spec/uap_clj/device_spec.clj
+++ b/spec/uap_clj/device_spec.clj
@@ -2,13 +2,10 @@
   "Test suite for device lookup functionality"
   (:require [speclj.core :refer :all]
             [uap-clj.device :refer :all]
-            [uap-clj.common-spec :refer [unknown-ua]]
-            [clj-yaml.core :refer [parse-string]]
-            [clojure.java.io :as io :refer [resource]]
+            [uap-clj.common-spec :refer [unknown-ua load-fixture]]
             [clojure.template :refer [do-template]]))
 
-(def tests (:test_cases (parse-string
-                          (slurp (io/resource "test_device.yaml")))))
+(def tests (load-fixture "test_device.yaml"))
 
 (defn run-device-fixture
   "Assert match between fixture test data:

--- a/spec/uap_clj/java/api/browser_spec.clj
+++ b/spec/uap_clj/java/api/browser_spec.clj
@@ -2,13 +2,10 @@
   "Test suite for Java API to browser lookup functionality"
   (:require [speclj.core :refer :all]
             [uap-clj.java.api.browser :refer [-lookup]]
-            [uap-clj.common-spec :refer [unknown-ua]]
-            [clj-yaml.core :refer [parse-string]]
-            [clojure.java.io :as io :refer [resource]]
+            [uap-clj.common-spec :refer [unknown-ua load-fixture]]
             [clojure.template :refer [do-template]]))
 
-(def tests (:test_cases (parse-string
-                          (slurp (io/resource "tests/test_ua.yaml")))))
+(def tests (load-fixture "tests/test_ua.yaml"))
 
 (defn run-browser-fixture
   "Assert match between fixture test data:

--- a/spec/uap_clj/java/api/device_spec.clj
+++ b/spec/uap_clj/java/api/device_spec.clj
@@ -2,13 +2,10 @@
   "Test suite for Java API to device lookup functionality"
   (:require [speclj.core :refer :all]
             [uap-clj.java.api.device :refer [-lookup]]
-            [uap-clj.common-spec :refer [unknown-ua]]
-            [clj-yaml.core :refer [parse-string]]
-            [clojure.java.io :as io :refer [resource]]
+            [uap-clj.common-spec :refer [unknown-ua load-fixture]]
             [clojure.template :refer [do-template]]))
 
-(def tests (:test_cases (parse-string
-                          (slurp (io/resource "tests/test_device.yaml")))))
+(def tests (load-fixture "tests/test_device.yaml"))
 
 (defn run-device-fixture
   "Assert match between fixture test data:

--- a/spec/uap_clj/java/api/os_spec.clj
+++ b/spec/uap_clj/java/api/os_spec.clj
@@ -2,13 +2,10 @@
   "Test suite for Java API to device lookup functionality"
   (:require [speclj.core :refer :all]
             [uap-clj.java.api.os :refer [-lookup]]
-            [uap-clj.common-spec :refer [unknown-ua]]
-            [clj-yaml.core :refer [parse-string]]
-            [clojure.java.io :as io :refer [resource]]
+            [uap-clj.common-spec :refer [unknown-ua load-fixture]]
             [clojure.template :refer [do-template]]))
 
-(def tests (:test_cases (parse-string
-                          (slurp (io/resource "tests/test_os.yaml")))))
+(def tests (load-fixture "tests/test_os.yaml"))
 
 (defn run-os-fixture
   "Assert match between fixture test data:

--- a/spec/uap_clj/os_spec.clj
+++ b/spec/uap_clj/os_spec.clj
@@ -2,13 +2,10 @@
   "Test suite for o/s lookup functionality"
   (:require [speclj.core :refer :all]
             [uap-clj.os :refer :all]
-            [uap-clj.common-spec :refer [unknown-ua]]
-            [clj-yaml.core :refer [parse-string]]
-            [clojure.java.io :as io :refer [resource]]
+            [uap-clj.common-spec :refer [unknown-ua load-fixture]]
             [clojure.template :refer [do-template]]))
 
-(def tests (:test_cases (parse-string
-                          (slurp (io/resource "test_os.yaml")))))
+(def tests (load-fixture "test_os.yaml"))
 
 (defn run-os-fixture
   "Assert match between fixture test data:


### PR DESCRIPTION
Addresses fix for https://nvd.nist.gov/vuln/detail/CVE-2022-38752

Relatedly, I've had to work around a test suite breakage _caused_ by that fix, since the Device suite test fixture exceeds the size of the CodePointLimit in the default snakeyaml LoaderOptions.